### PR TITLE
Update test paths for Library and Channel pages

### DIFF
--- a/js/album.js
+++ b/js/album.js
@@ -51,7 +51,7 @@ class Album {
      *
      * @param {Album} that - Album to be compared for equality.
      *
-     * @returns {boolean} - True iff the albums contain the same video IDs.
+     * @returns {boolean} - True if the albums contain the same video IDs.
      */
     equals(that) {
         const this_ids = new Set(this.getIDs());

--- a/js/page.js
+++ b/js/page.js
@@ -10,7 +10,7 @@
  * @returns {boolean} - True iff the given element and path describe a channel page.
  */
 function isChannelPage(element, _) {
-    return element.querySelector("ytd-browse[page-subtype=channels]:not([hidden]) #channel-container") !== null;
+    return element.querySelector("ytd-browse[page-subtype=channels]:not([hidden]) #channel-name") !== null;
 }
 
 /**
@@ -43,7 +43,7 @@ function isExplorePage(_, path) {
  * @returns {boolean} - True iff the given element and path describe the Library page.
  */
 function isLibraryPage(_, path) {
-    return new RegExp("/feed/library").test(path);
+    return new RegExp("/feed/library").test(path) || new RegExp("/feed/you").test(path);
 }
 
 /**

--- a/js/page.js
+++ b/js/page.js
@@ -7,7 +7,7 @@
  * 
  * @param {Element} _ - HTML element representing the YouTube page.
  * @param {string} path - Path and query components of the YouTube page URL.
- * @returns {boolean} - True iff the given element and path describe a channel page.
+ * @returns {boolean} - True if the given element and path describe a channel page.
  */
 function isChannelPage(element, _) {
     return element.querySelector("ytd-browse[page-subtype=channels]:not([hidden]) #channel-name") !== null;
@@ -18,7 +18,7 @@ function isChannelPage(element, _) {
  * 
  * @param {Element} _ - HTML element representing the YouTube page.
  * @param {string} path - Path and query components of the YouTube page URL.
- * @returns {boolean} - True iff the given element and path describe the Home page.
+ * @returns {boolean} - True if the given element and path describe the Home page.
  */
 function isHomePage(_, path) {
     return new RegExp("/$").test(path);
@@ -29,7 +29,7 @@ function isHomePage(_, path) {
  * 
  * @param {Element} _ - HTML element representing the YouTube page.
  * @param {string} path - Path and query components of the YouTube page URL.
- * @returns {boolean} - True iff the given element and path describe the Explore page.
+ * @returns {boolean} - True if the given element and path describe the Explore page.
  */
 function isExplorePage(_, path) {
     return new RegExp("/feed/explore").test(path);
@@ -40,7 +40,7 @@ function isExplorePage(_, path) {
  * 
  * @param {Element} _ - HTML element representing the YouTube page.
  * @param {string} path - Path and query components of the YouTube page URL.
- * @returns {boolean} - True iff the given element and path describe the Library page.
+ * @returns {boolean} - True if the given element and path describe the Library page.
  */
 function isLibraryPage(_, path) {
     return new RegExp("/feed/library").test(path) || new RegExp("/feed/you").test(path);
@@ -51,7 +51,7 @@ function isLibraryPage(_, path) {
  * 
  * @param {Element} _ - HTML element representing the YouTube page.
  * @param {string} path - Path and query components of the YouTube page URL.
- * @returns {boolean} - True iff the given element and path describe the History page.
+ * @returns {boolean} - True if the given element and path describe the History page.
  */
 function isHistoryPage(_, path) {
     return new RegExp("/feed/history").test(path);
@@ -62,7 +62,7 @@ function isHistoryPage(_, path) {
  * 
  * @param {Element} _ - HTML element representing the YouTube page.
  * @param {string} path - Path and query components of the YouTube page URL.
- * @returns {boolean} - True iff the given element and path describe the Subscriptions page.
+ * @returns {boolean} - True if the given element and path describe the Subscriptions page.
  */
 function isSubscriptionsPage(_, path) {
     return new RegExp("/feed/subscriptions").test(path);

--- a/js/settings.js
+++ b/js/settings.js
@@ -18,7 +18,7 @@ class Settings {
      * Reports whether watched videos on the current page should be ignored,
      * taking into account the YouTube page filters.
      *
-     * @returns {boolean} - True iff watched videos should be ignored.
+     * @returns {boolean} - True if watched videos should be ignored.
      */
     ignored() {
         const page = Path.parse(window.location.toString());
@@ -46,7 +46,7 @@ class Settings {
      * taking into account the state of the universal Hide Videos toggle and
      * bookmarks.
      *
-     * @returns {boolean} - True iff watched videos should be hidden.
+     * @returns {boolean} - True if watched videos should be hidden.
      */
     hidden() {
         const page = Path.parse(window.location.toString());


### PR DESCRIPTION
The "Channels" and "Library" settings under "Pages" don't work.

Interesting for Library, both "/feed/you" and "/feed/library" both point to the same page, but the former seems to be the more correct one these days. 

As for the Channels page test, the CSS has apparently had a name change.

I've only verified these changes on Firefox, but I can't imagine the tests would be different for Chrome.